### PR TITLE
Add 'engineRetries' to pipeline sample snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To install the plugin manually:
    node {
      def imageLine = '6cba161501c8' + ' ' + env.WORKSPACE + '/DockerFile'
      writeFile file: 'anchore_images', text: imageLine
-     anchore name: 'anchore_images', inputQueries: [[query: 'list-packages all'], [query: 'list-files all'], [query: 'cve-scan all'], [query: 'show-pkg-diffs base']]
+     anchore name: 'anchore_images', engineRetries: '300', inputQueries: [[query: 'list-packages all'], [query: 'list-files all'], [query: 'cve-scan all'], [query: 'show-pkg-diffs base']]
    }
    ```
 


### PR DESCRIPTION
You need to include 'engineRetries' if using a Pipeline script.  If not, you end up with the following error:

`2017-10-14T09:57:37.611 ERROR  AnchoreWorker   Failed to run Anchore gates due to an unexpected error
java.lang.NumberFormatException: null
	at java.lang.Integer.parseInt(Integer.java:542)
	at java.lang.Integer.parseInt(Integer.java:615)
	at com.anchore.jenkins.plugins.anchore.BuildWorker.runGatesEngine(BuildWorker.java:397)
	at com.anchore.jenkins.plugins.anchore.BuildWorker.runGates(BuildWorker.java:362)
	at com.anchore.jenkins.plugins.anchore.AnchoreBuilder.perform(AnchoreBuilder.java:312)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:80)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:67)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1$1.call(SynchronousNonBlockingStepExecution.java:49)
	at hudson.security.ACL.impersonate(ACL.java:260)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1.run(SynchronousNonBlockingStepExecution.java:46)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)`