### PR TITLE
Improved Jenkins integration

### DIFF
--- a/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreAction.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreAction.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import jenkins.model.Jenkins;
+import jenkins.model.RunAction2;
 import jenkins.model.lazy.LazyBuildMixIn;
 import jenkins.tasks.SimpleBuildStep;
 import jenkins.util.NonLocalizable;
@@ -21,9 +22,9 @@ import net.sf.json.JSONObject;
  * the results is defined in the appropriate index and summary jelly files. This Jenkins Action is associated with a build (and not the
  * project which is one level up)
  */
-public class AnchoreAction implements HealthReportingAction, SimpleBuildStep.LastBuildAction {
+public class AnchoreAction implements HealthReportingAction, SimpleBuildStep.LastBuildAction, RunAction2 {
 
-  private Run<?, ?> build;
+  private transient Run<?, ?> build;
   private String gateStatus;
   private String gateOutputUrl;
   private Map<String, String> queryOutputUrls;
@@ -42,10 +43,9 @@ public class AnchoreAction implements HealthReportingAction, SimpleBuildStep.Las
   private Map<String, String> queries;
 
 
-  public AnchoreAction(Run<?, ?> build, String gateStatus, final String jenkinsOutputDirName, String gateReport,
+  public AnchoreAction(String gateStatus, final String jenkinsOutputDirName, String gateReport,
       Map<String, String> queryReports, String gateSummary, String cveListingFileName,
       int stopActionCount, int warnActionCount, int goActionCount, double warnActionHealthFactor, double stopActionHealthFactor) {
-    this.build = build;
     this.gateStatus = gateStatus;
     this.stopActionCount = stopActionCount;
     this.warnActionCount = warnActionCount;
@@ -77,7 +77,17 @@ public class AnchoreAction implements HealthReportingAction, SimpleBuildStep.Las
       this.cveListingUrl = "../artifact/" + jenkinsOutputDirName + "/" + cveListingFileName;
     }
   }
+  
+  @Override
+  public void onAttached(Run<?, ?> r){
+    this.build = r;
+  }
 
+  @Override
+  public void onLoad(Run<?, ?> r){
+    this.build = r;
+  }
+  
   @Override
   public String getIconFileName() {
     return Jenkins.RESOURCE_PATH + "/plugin/anchore-container-scanner/images/anchore.png";

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreBuilder.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreBuilder.java
@@ -74,6 +74,9 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
   private String bundleFileOverride = DescriptorImpl.DEFAULT_BUNDLE_FILE_OVERRIDE;
   private List<AnchoreQuery> inputQueries;
   private String policyBundleId = DescriptorImpl.DEFAULT_POLICY_BUNDLE_ID;
+  private double stopActionHealthFactor = DescriptorImpl.DEFAULT_STOP_ACTION_HEALTH_FACTOR;
+  private double warnActionHealthFactor = DescriptorImpl.DEFAULT_WARN_ACTION_HEALTH_FACTOR;
+  
   private List<Annotation> annotations;
 
   // Override global config. Supported for anchore-engine mode config only
@@ -146,6 +149,14 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
 
   public String getPolicyBundleId() {
     return policyBundleId;
+  }
+  
+  public double getWarnActionHealthFactor(){
+    return warnActionHealthFactor;
+  }
+  
+  public double getStopActionHealthFactor(){
+    return stopActionHealthFactor;
   }
 
   public List<Annotation> getAnnotations() {
@@ -241,6 +252,16 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
   }
 
   @DataBoundSetter
+  public void setWarnActionHealthFactor(double warnActionHealthFactor){
+    this.warnActionHealthFactor = warnActionHealthFactor;
+  }
+
+  @DataBoundSetter
+  public void setStopActionHealthFactor(double stopActionHealthFactor){
+    this.stopActionHealthFactor = stopActionHealthFactor;
+  }
+  
+  @DataBoundSetter
   public void setAnnotations(List<Annotation> annotations) {
     this.annotations = annotations;
   }
@@ -311,7 +332,7 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
       /* Instantiate config and a new build worker */
       config = new BuildConfig(name, policyName, globalWhiteList, anchoreioUser, anchoreioPass, userScripts, engineRetries, bailOnFail,
           bailOnWarn, bailOnPluginFail, doCleanup, useCachedBundle, policyEvalMethod, bundleFileOverride, inputQueries, policyBundleId,
-          annotations, globalConfig.getDebug(), globalConfig.getEnginemode(),
+          warnActionHealthFactor, stopActionHealthFactor, annotations, globalConfig.getDebug(), globalConfig.getEnginemode(),
           // messy build time overrides, ugh!
           !Strings.isNullOrEmpty(engineurl) ? engineurl : globalConfig.getEngineurl(),
           !Strings.isNullOrEmpty(engineuser) ? engineuser : globalConfig.getEngineuser(),
@@ -418,6 +439,8 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
         .of(new AnchoreQuery("cve-scan all"), new AnchoreQuery("list-packages all"), new AnchoreQuery("list-files all"),
             new AnchoreQuery("show-pkg-diffs base"));
     public static final String DEFAULT_POLICY_BUNDLE_ID = "";
+    public static final double DEFAULT_STOP_ACTION_HEALTH_FACTOR = 25;
+    public static final double DEFAULT_WARN_ACTION_HEALTH_FACTOR = 5;
     public static final String EMPTY_STRING = "";
 
     // Global configuration

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreProjectAction.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreProjectAction.java
@@ -1,0 +1,243 @@
+package com.anchore.jenkins.plugins.anchore;
+
+import hudson.Functions;
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.util.Area;
+import hudson.util.ColorPalette;
+import hudson.util.DataSetBuilder;
+import hudson.util.Graph;
+import hudson.util.ShiftedCategoryAxis;
+import hudson.util.StackedAreaRenderer2;
+import hudson.util.ChartUtil.NumberOnlyBuildLabel;
+import jenkins.model.Jenkins;
+
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.CategoryAxis;
+import org.jfree.chart.axis.CategoryLabelPositions;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.plot.CategoryPlot;
+import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.renderer.category.StackedAreaRenderer;
+import org.jfree.data.category.CategoryDataset;
+import org.jfree.ui.RectangleInsets;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import javax.servlet.http.HttpServletResponse;
+
+import java.awt.Color;
+import java.io.IOException;
+
+/**
+ * Project action object which displays the trend report on the project top page.
+ */
+public class AnchoreProjectAction implements Action {
+  private final static class AnchoreTrendGraph extends Graph {
+    private AnchoreAction base;
+    private String relPath;
+
+    private static Area calcDefaultSize() {
+      Area res = Functions.getScreenResolution();
+      if(res!=null && res.width<=800)
+        return new Area(250,100);
+      else
+        return new Area(500,200);
+    }
+    
+    /**
+     * Initialize the trend graph from a base AnchoreAction using a calculated default size.
+     *
+     * @param base the most recent AnchoreAction up to which the trend is shown
+     * @param relPath URL rel path for tooltip URLs
+     */
+    protected AnchoreTrendGraph(AnchoreAction base, String relPath){
+      this(base, calcDefaultSize(), relPath);
+    }
+
+    /**
+     * Initialize the trend graph from a base AnchoreAction using a given default size.
+     *
+     * @param base the most recent AnchoreAction up to which the trend is shown
+     * @param defaultSize graph's default size
+     * @param relPath URL rel path for tooltip URLs
+     */
+    private AnchoreTrendGraph(AnchoreAction base, Area defaultSize, String relPath){
+      super(base.getBuild().getTimestamp(), defaultSize.width, defaultSize.height);
+      this.base = base;
+      this.relPath = relPath;
+    }
+
+    private CategoryDataset buildDataSet() {
+      DataSetBuilder<String, NumberOnlyBuildLabel> dsb = new DataSetBuilder<>();
+
+      int cap = Integer.getInteger(AnchoreAction.class.getName() + ".anchore.trend.max", Integer.MAX_VALUE);
+      int count = 0;
+      for (AnchoreAction a = this.base; a != null; a = a.getPreviousResult()) {
+        if (++count > cap) {
+          break;
+        }
+        dsb.add(a.getGoActionCount(), "0_go", new NumberOnlyBuildLabel(a.getBuild()));
+        dsb.add(a.getWarnActionCount(), "1_warn", new NumberOnlyBuildLabel(a.getBuild()));
+        dsb.add(a.getStopActionCount(), "2_stop", new NumberOnlyBuildLabel(a.getBuild()));
+      }
+      return dsb.build();
+    }
+    
+    @Override
+    protected JFreeChart createGraph(){
+      CategoryDataset dataset = buildDataSet();
+      final JFreeChart chart = ChartFactory.createStackedAreaChart(
+        null, // chart title
+        null, // category axis label
+        "count", // range axis label
+        dataset,
+        PlotOrientation.VERTICAL,
+        false, // include legend
+        true, // generate tooltips
+        false // generate urls
+      );
+
+      chart.setBackgroundPaint(Color.white);
+
+      final CategoryPlot plot = chart.getCategoryPlot();
+
+      plot.setBackgroundPaint(Color.WHITE);
+      plot.setOutlinePaint(null);
+      plot.setForegroundAlpha(0.8f);
+      plot.setRangeGridlinesVisible(true);
+      plot.setRangeGridlinePaint(Color.BLACK);
+
+      CategoryAxis domainAxis = new ShiftedCategoryAxis(null);
+      plot.setDomainAxis(domainAxis);
+      domainAxis.setCategoryLabelPositions(CategoryLabelPositions.UP_90);
+      domainAxis.setLowerMargin(0.0);
+      domainAxis.setUpperMargin(0.0);
+      domainAxis.setCategoryMargin(0.0);
+
+      final NumberAxis rangeAxis = (NumberAxis) plot.getRangeAxis();
+      rangeAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits());
+
+      StackedAreaRenderer ar = new StackedAreaRenderer2() {
+        @Override
+        public String generateURL(CategoryDataset data, int row, int column) {
+          NumberOnlyBuildLabel label = (NumberOnlyBuildLabel) data.getColumnKey(column);
+          return relPath + label.getRun().getNumber() + "/anchore-results/";
+        }
+    
+        @Override
+        public String generateToolTip(CategoryDataset data, int row, int column) {
+          NumberOnlyBuildLabel label = (NumberOnlyBuildLabel) data.getColumnKey(column);
+          AnchoreAction a = label.getRun().getAction(AnchoreAction.class);
+          switch (row) {
+            case 0:
+              return label.getRun().getDisplayName() + ": " + a.getGoActionCount() + " Go Actions";
+            case 1:
+              return label.getRun().getDisplayName() + ": " + a.getWarnActionCount() + " Warn Actions";
+            default:
+              return label.getRun().getDisplayName() + ": " + a.getStopActionCount() + " Stop Actions";
+          }
+        }
+      };
+      ar.setSeriesPaint(0, ColorPalette.BLUE); // Go
+      ar.setSeriesPaint(1, ColorPalette.YELLOW); // Warn
+      ar.setSeriesPaint(2, ColorPalette.RED); // Stop
+      plot.setRenderer(ar);
+
+      plot.setInsets(new RectangleInsets(0, 0, 0, 5.0));
+
+      return chart;
+    }
+  }
+  
+  /**
+   * Parent that owns this action.
+   */
+  public final Job<?,?> job;
+
+  /**
+   * Create new AnchoreProjectAction instance.
+   *
+   * @param job
+   */
+  public AnchoreProjectAction(Job<?,?> job) {
+    this.job = job;
+  }
+
+  @Override
+  public String getIconFileName() {
+    return Jenkins.RESOURCE_PATH + "/plugin/anchore-container-scanner/images/anchore.png";
+  }
+
+  @Override
+  public String getDisplayName() {
+    return "Anchore Report";
+  }
+
+  @Override
+  public String getUrlName() {
+    return "anchore";
+  }
+  
+  /**
+   * Redirects the index page to the last report.
+   *
+   * @param request Stapler request
+   * @param response Stapler response
+   * @throws IOException in case of an error
+   */
+  public void doIndex(final StaplerRequest request, final StaplerResponse response) throws IOException {
+    Run<?, ?> lastRun = this.job.getLastCompletedBuild();
+    if (lastRun != null) {
+      AnchoreAction a = lastRun.getAction(AnchoreAction.class);
+      if (a != null)
+        response.sendRedirect2(String.format("../%d/%s", lastRun.getNumber(), a.getUrlName()));
+    }
+  }
+
+  /**
+   * @return the most current AnchoreAction of the associated job
+   */
+  public AnchoreAction getLastAnchoreAction() {
+    final Run<?,?> tb = this.job.getLastSuccessfulBuild();
+
+    Run<?,?> b = this.job.getLastBuild();
+    while (b != null) {
+      AnchoreAction a = b.getAction(AnchoreAction.class);
+      if (a != null && (!b.isBuilding())) {
+        return a;
+      }
+      if (b == tb) {
+        // no Anchore result available
+        return null;
+      }
+      b = b.getPreviousBuild();
+    }
+    return null;
+  }
+  
+  private String getRelPath(StaplerRequest req) {
+      String relPath = req.getParameter("rel");
+      if (relPath == null) {
+        return "";
+      }
+      return relPath;
+  }
+  
+  /**
+   * Generates the Anchore trend graph
+   * @return graph object
+   */
+  public Graph getTrendGraph() {
+    final AnchoreAction a = getLastAnchoreAction();
+    if (a != null) {
+      return new AnchoreTrendGraph(a, getRelPath(Stapler.getCurrentRequest()));
+    }else{
+      Stapler.getCurrentResponse().setStatus(HttpServletResponse.SC_NOT_FOUND);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/BuildConfig.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/BuildConfig.java
@@ -27,6 +27,8 @@ public class BuildConfig {
   private String bundleFileOverride;
   private List<AnchoreQuery> inputQueries;
   private String policyBundleId;
+  private double warnActionHealthFactor;
+  private double stopActionHealthFactor;
 
   private List<Annotation> annotations;
 
@@ -46,9 +48,9 @@ public class BuildConfig {
   public BuildConfig(String name, String policyName, String globalWhiteList, String anchoreioUser, String anchoreioPass,
       String userScripts, String engineRetries, boolean bailOnFail, boolean bailOnWarn, boolean bailOnPluginFail, boolean doCleanup,
       boolean useCachedBundle, String policyEvalMethod, String bundleFileOverride, List<AnchoreQuery> inputQueries,
-      String policyBundleId, List<Annotation> annotations, boolean debug, String enginemode, String engineurl, String engineuser,
-      String enginepass, boolean engineverify, String containerImageId, String containerId, String localVol, String modulesVol,
-      boolean useSudo) {
+      String policyBundleId, double warnActionHealthFactor, double stopActionHealthFactor, List<Annotation> annotations, boolean debug, String enginemode,
+      String engineurl, String engineuser, String enginepass, boolean engineverify, String containerImageId, String containerId,
+      String localVol, String modulesVol, boolean useSudo) {
     this.name = name;
     this.policyName = policyName;
     this.globalWhiteList = globalWhiteList;
@@ -65,6 +67,8 @@ public class BuildConfig {
     this.bundleFileOverride = bundleFileOverride;
     this.inputQueries = inputQueries;
     this.policyBundleId = policyBundleId;
+    this.warnActionHealthFactor = warnActionHealthFactor;
+    this.stopActionHealthFactor = stopActionHealthFactor;
     this.annotations = annotations;
     this.debug = debug;
     this.enginemode = enginemode;
@@ -147,6 +151,14 @@ public class BuildConfig {
     return policyBundleId;
   }
 
+  public double getStopActionHealthFactor(){
+    return stopActionHealthFactor;
+  }
+  
+  public double getWarnActionHealthFactor(){
+    return warnActionHealthFactor;
+  }
+  
   public List<Annotation> getAnnotations() {
     return annotations;
   }
@@ -224,6 +236,8 @@ public class BuildConfig {
       }
       consoleLog.logInfo("[build] bailOnFail: " + bailOnFail);
       consoleLog.logInfo("[build] bailOnPluginFail: " + bailOnPluginFail);
+      consoleLog.logInfo("[build] warnActionHealthFactor: " + warnActionHealthFactor);
+      consoleLog.logInfo("[build] stopActionHealthFactor: " + stopActionHealthFactor);
     } else {
       // Global properties
       consoleLog.logInfo("[global] containerImageId: " + containerImageId);
@@ -255,6 +269,8 @@ public class BuildConfig {
       consoleLog.logInfo("[build] bailOnFail: " + bailOnFail);
       consoleLog.logInfo("[build] bailOnWarn: " + bailOnWarn);
       consoleLog.logInfo("[build] bailOnPluginFail: " + bailOnPluginFail);
+      consoleLog.logInfo("[build] warnActionHealthFactor: " + warnActionHealthFactor);
+      consoleLog.logInfo("[build] stopActionHealthFactor: " + stopActionHealthFactor);
     }
   }
 }

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/BuildConfig.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/BuildConfig.java
@@ -29,6 +29,10 @@ public class BuildConfig {
   private String policyBundleId;
   private double warnActionHealthFactor;
   private double stopActionHealthFactor;
+  private Integer unstableStopThreshold;
+  private Integer unstableWarnThreshold;
+  private Integer failedStopThreshold;
+  private Integer failedWarnThreshold;
 
   private List<Annotation> annotations;
 
@@ -46,11 +50,13 @@ public class BuildConfig {
   private boolean useSudo;
 
   public BuildConfig(String name, String policyName, String globalWhiteList, String anchoreioUser, String anchoreioPass,
-      String userScripts, String engineRetries, boolean bailOnFail, boolean bailOnWarn, boolean bailOnPluginFail, boolean doCleanup,
-      boolean useCachedBundle, String policyEvalMethod, String bundleFileOverride, List<AnchoreQuery> inputQueries,
-      String policyBundleId, double warnActionHealthFactor, double stopActionHealthFactor, List<Annotation> annotations, boolean debug, String enginemode,
-      String engineurl, String engineuser, String enginepass, boolean engineverify, String containerImageId, String containerId,
-      String localVol, String modulesVol, boolean useSudo) {
+      String userScripts, String engineRetries, boolean bailOnFail, boolean bailOnWarn, boolean bailOnPluginFail,
+      boolean doCleanup, boolean useCachedBundle, String policyEvalMethod, String bundleFileOverride,
+      List<AnchoreQuery> inputQueries, String policyBundleId, double warnActionHealthFactor,
+      double stopActionHealthFactor, Integer unstableStopThreshold, Integer unstableWarnThreshold, Integer failedStopThreshold,
+      Integer failedWarnThreshold, List<Annotation> annotations, boolean debug, String enginemode, String engineurl,
+      String engineuser, String enginepass, boolean engineverify, String containerImageId, String containerId,
+      String localVol, String modulesVol, boolean useSudo){
     this.name = name;
     this.policyName = policyName;
     this.globalWhiteList = globalWhiteList;
@@ -69,6 +75,10 @@ public class BuildConfig {
     this.policyBundleId = policyBundleId;
     this.warnActionHealthFactor = warnActionHealthFactor;
     this.stopActionHealthFactor = stopActionHealthFactor;
+    this.unstableStopThreshold = unstableStopThreshold;
+    this.unstableWarnThreshold = unstableWarnThreshold;
+    this.failedStopThreshold = failedStopThreshold;
+    this.failedWarnThreshold = failedWarnThreshold;
     this.annotations = annotations;
     this.debug = debug;
     this.enginemode = enginemode;
@@ -158,6 +168,22 @@ public class BuildConfig {
   public double getWarnActionHealthFactor(){
     return warnActionHealthFactor;
   }
+
+  public Integer getUnstableStopThreshold(){
+    return unstableStopThreshold;
+  }
+
+  public Integer getUnstableWarnThreshold(){
+    return unstableWarnThreshold;
+  }
+
+  public Integer getFailedStopThreshold(){
+    return failedStopThreshold;
+  }
+
+  public Integer getFailedWarnThreshold(){
+    return failedWarnThreshold;
+  }
   
   public List<Annotation> getAnnotations() {
     return annotations;
@@ -238,6 +264,10 @@ public class BuildConfig {
       consoleLog.logInfo("[build] bailOnPluginFail: " + bailOnPluginFail);
       consoleLog.logInfo("[build] warnActionHealthFactor: " + warnActionHealthFactor);
       consoleLog.logInfo("[build] stopActionHealthFactor: " + stopActionHealthFactor);
+      consoleLog.logInfo("[build] unstableStopThreshold: " + unstableStopThreshold);
+      consoleLog.logInfo("[build] unstableWarnThreshold: " + unstableWarnThreshold);
+      consoleLog.logInfo("[build] failedStopThreshold: " + failedStopThreshold);
+      consoleLog.logInfo("[build] failedWarnThreshold: " + failedWarnThreshold);
     } else {
       // Global properties
       consoleLog.logInfo("[global] containerImageId: " + containerImageId);
@@ -271,6 +301,10 @@ public class BuildConfig {
       consoleLog.logInfo("[build] bailOnPluginFail: " + bailOnPluginFail);
       consoleLog.logInfo("[build] warnActionHealthFactor: " + warnActionHealthFactor);
       consoleLog.logInfo("[build] stopActionHealthFactor: " + stopActionHealthFactor);
+      consoleLog.logInfo("[build] unstableStopThreshold: " + unstableStopThreshold);
+      consoleLog.logInfo("[build] unstableWarnThreshold: " + unstableWarnThreshold);
+      consoleLog.logInfo("[build] failedStopThreshold: " + failedStopThreshold);
+      consoleLog.logInfo("[build] failedWarnThreshold: " + failedWarnThreshold);
     }
   }
 }

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
@@ -936,13 +936,10 @@ public class BuildWorker {
       console.logDebug("Setting up build results");
 
       
-      if (finalAction != null) {
-        build.addAction(new AnchoreAction(build, finalAction.toString(), jenkinsOutputDirName, gateOutputFileName, queryOutputMap,
-            gateSummary.toString(), cveListingFileName, totalStopActionCount, totalWarnActionCount, totalGoActionCount));
-      } else {
-        build.addAction(new AnchoreAction(build, "", jenkinsOutputDirName, gateOutputFileName, queryOutputMap, gateSummary.toString(),
-            cveListingFileName, totalStopActionCount, totalWarnActionCount, totalGoActionCount));
-      }
+      build.addAction(new AnchoreAction(build, finalAction != null ? finalAction.toString() : "", jenkinsOutputDirName,
+          gateOutputFileName, queryOutputMap, gateSummary.toString(), cveListingFileName, totalStopActionCount,
+          totalWarnActionCount, totalGoActionCount, config.getWarnActionHealthFactor(),
+          config.getStopActionHealthFactor()));
       //    } catch (AbortException e) { // probably caught one of the thrown exceptions, let it pass through
       //      throw e;
     } catch (Exception e) { // caught unknown exception, log it and wrap it

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
@@ -936,7 +936,7 @@ public class BuildWorker {
       console.logDebug("Setting up build results");
 
       
-      build.addAction(new AnchoreAction(build, finalAction != null ? finalAction.toString() : "", jenkinsOutputDirName,
+      build.addAction(new AnchoreAction(finalAction != null ? finalAction.toString() : "", jenkinsOutputDirName,
           gateOutputFileName, queryOutputMap, gateSummary.toString(), cveListingFileName, totalStopActionCount,
           totalWarnActionCount, totalGoActionCount, config.getWarnActionHealthFactor(),
           config.getStopActionHealthFactor()));

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
@@ -83,6 +83,9 @@ public class BuildWorker {
   private String gateOutputFileName;
   private GATE_ACTION finalAction;
   private JSONObject gateSummary;
+  private int totalStopActionCount = 0;
+  private int totalWarnActionCount = 0;
+  private int totalGoActionCount = 0;
   private String cveListingFileName;
 
   // Initialized by Anchore workspace prep
@@ -697,6 +700,10 @@ public class BuildWorker {
                 }
               }
 
+              totalStopActionCount += (stop - stop_wl);
+              totalWarnActionCount += (warn - warn_wl);
+              totalGoActionCount += (go - go_wl);
+              
               if (!Strings.isNullOrEmpty(repoTag)) {
                 console.logInfo("Policy evaluation summary for " + repoTag + " - stop: " + (stop - stop_wl) + " (+" + stop_wl
                     + " whitelisted), warn: " + (warn - warn_wl) + " (+" + warn_wl + " whitelisted), go: " + (go - go_wl) + " (+"
@@ -928,12 +935,13 @@ public class BuildWorker {
       // add the link in jenkins UI for anchore results
       console.logDebug("Setting up build results");
 
+      
       if (finalAction != null) {
         build.addAction(new AnchoreAction(build, finalAction.toString(), jenkinsOutputDirName, gateOutputFileName, queryOutputMap,
-            gateSummary.toString(), cveListingFileName));
+            gateSummary.toString(), cveListingFileName, totalStopActionCount, totalWarnActionCount, totalGoActionCount));
       } else {
         build.addAction(new AnchoreAction(build, "", jenkinsOutputDirName, gateOutputFileName, queryOutputMap, gateSummary.toString(),
-            cveListingFileName));
+            cveListingFileName, totalStopActionCount, totalWarnActionCount, totalGoActionCount));
       }
       //    } catch (AbortException e) { // probably caught one of the thrown exceptions, let it pass through
       //      throw e;

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/config.jelly
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/config.jelly
@@ -23,6 +23,44 @@
         <f:number default="${descriptor.DEFAULT_STOP_ACTION_HEALTH_FACTOR}" min="0" step="1.0" size="10"/>
     </f:entry>
     
+    <f:entry title="Status thresholds" help="/plugin/anchore-container-scanner/help/help-StatusThresholds.html">
+	    <table>
+			<thead>
+				<tr>
+					<td />
+					<td>Stop actions</td>
+					<td>Warn actions</td>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td style="vertical-align: middle;">
+						<img src="${resURL}/images/24x24/yellow.png" alt="Unstable"
+							class="icon-yellow icon-md" title="Unstable thresholds" />
+					</td>
+					<td>
+	        			<f:number field="unstableStopThreshold" default="${descriptor.DEFAULT_UNSTABLE_STOP_THRESHOLD}" min="1" step="1" size="10"/>
+					</td>
+					<td>
+	        			<f:number field="unstableWarnThreshold" default="${descriptor.DEFAULT_UNSTABLE_WARN_THRESHOLD}" min="1" step="1" size="10"/>
+					</td>
+				</tr>
+				<tr>
+					<td style="vertical-align: middle;">
+						<img src="${resURL}/images/24x24/red.png" alt="Failed"
+							class="icon-red icon-md" title="Failed thresholds" />
+					</td>
+					<td>
+	        			<f:number field="failedStopThreshold" default="${descriptor.DEFAULT_FAILED_STOP_THRESHOLD}" min="1" step="1" size="10"/>
+					</td>
+					<td>
+	        			<f:number field="failedWarnThreshold" default="${descriptor.DEFAULT_FAILED_WARN_THRESHOLD}" min="1" step="1" size="10"/>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</f:entry>
+    
     <j:choose>
       <j:when test="${descriptor.isMode('anchoreengine')}">
         <f:entry title="Anchore Engine operation retries" field="engineRetries">

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/config.jelly
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/config.jelly
@@ -15,6 +15,14 @@
       <f:checkbox name="bailOnPluginFail" checked="${instance.bailOnPluginFail}" default="${descriptor.DEFAULT_BAIL_ON_PLUGIN_FAIL}"/>
     </f:entry>
 
+    <f:entry title="Health warn action amplification factor" field="warnActionHealthFactor">
+        <f:number default="${descriptor.DEFAULT_WARN_ACTION_HEALTH_FACTOR}" min="0" step="1.0" size="10"/>
+    </f:entry>
+    
+    <f:entry title="Health stop action amplification factor" field="stopActionHealthFactor">
+        <f:number default="${descriptor.DEFAULT_STOP_ACTION_HEALTH_FACTOR}" min="0" step="1.0" size="10"/>
+    </f:entry>
+    
     <j:choose>
       <j:when test="${descriptor.isMode('anchoreengine')}">
         <f:entry title="Anchore Engine operation retries" field="engineRetries">

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/help-stopActionHealthFactor.html
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/help-stopActionHealthFactor.html
@@ -1,0 +1,17 @@
+<div>
+    The amplification factor to apply to stop actions when computing the build health score.
+    <br />
+    The default factor is <code>25.0</code>
+    <ul>
+        <li>A factor of <code>0.0</code> means that stop actions will not influence the build health score.</li>
+        <li>A factor of <code>0.1</code> means that 10 stop actions result in 99% health</li>
+        <li>A factor of <code>0.5</code> means that 10 stop actions result in 95% health</li>
+        <li>A factor of <code>1.0</code> means that 10 stop actions result in 90% health</li>
+        <li>A factor of <code>2.0</code> means that 10 stop actions result in 80% health</li>
+        <li>A factor of <code>2.5</code> means that 10 stop actions result in 75% health</li>
+        <li>A factor of <code>5.0</code> means that 10 stop actions result in 50% health</li>
+        <li>A factor of <code>10.0</code> means that 10 stop actions result in 0% health</li>
+        <li>A factor of <code>25.0</code> means that 1 stop action results in 75% health</li>
+    </ul>
+    The factor is persisted with the build results, so changes will only be reflected in new builds.
+</div>

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/help-warnActionHealthFactor.html
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/help-warnActionHealthFactor.html
@@ -1,0 +1,17 @@
+<div>
+    The amplification factor to apply to warn actions when computing the build health score.
+    <br />
+    The default factor is <code>5.0</code>
+    <ul>
+        <li>A factor of <code>0.0</code> means that warn actions will not influence the build health score.</li>
+        <li>A factor of <code>0.1</code> means that 10 warn actions result in 99% health</li>
+        <li>A factor of <code>0.5</code> means that 10 warn actions result in 95% health</li>
+        <li>A factor of <code>1.0</code> means that 10 warn actions result in 90% health</li>
+        <li>A factor of <code>2.0</code> means that 10 warn actions result in 80% health</li>
+        <li>A factor of <code>2.5</code> means that 10 warn actions result in 75% health</li>
+        <li>A factor of <code>5.0</code> means that 10 warn actions result in 50% health</li>
+        <li>A factor of <code>10.0</code> means that 10 warn actions result in 0% health</li>
+        <li>A factor of <code>25.0</code> means that 1 warn action results in 75% health</li>
+    </ul>
+    The factor is persisted with the build results, so changes will only be reflected in new builds.
+</div>

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreProjectAction/detailGraph.jelly
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreProjectAction/detailGraph.jelly
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <l:layout title="Anchore trend chart">
+    <st:include page="sidepanel.jelly" it="${it.job}" />
+    <l:main-panel>
+      <div>
+        <img src="trendGraph/png?${request.queryString}" lazymap="trendGraph/map?rel=../&amp;${request.queryString}" alt="[Anchore trend chart]"/>
+      </div>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreProjectAction/floatingBox.jelly
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreProjectAction/floatingBox.jelly
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <j:set var="ar" value="${action.lastAnchoreAction}" />
+  <j:if test="${ar.previousResult!=null}">
+    <!-- at least two data points are required for a trend report -->
+    <div align="right">
+      <div class="test-trend-caption">
+        Anchore Trend
+      </div>
+      <div>
+        <img src="anchore/trendGraph/png" lazymap="anchore/trendGraph/map" alt="[Anchore trend chart]"/>
+      </div>
+      <div style="text-align:right">
+        <a href="anchore/detailGraph?width=800&amp;height=600">Enlarge</a>
+      </div>
+    </div>
+  </j:if>
+</j:jelly>

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreProjectAction/jobMain.jelly
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreProjectAction/jobMain.jelly
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
+    <table style="margin-top: 1em; margin-left: 1em;">
+        <j:set var="ar" value="${it.job.lastCompletedBuild.getAction(it.class.classLoader.loadClass('com.anchore.jenkins.plugins.anchore.AnchoreAction'))}"/>
+        <j:if test="${ar != null}">
+        	<t:summary href="lastCompletedBuild/${ar.urlName}/" icon="/plugin/anchore-container-scanner/images/anchore.png">
+		    	<j:out value="Latest Anchore Report (${ar.gateStatus})" />
+		    </t:summary>
+        </j:if>
+    </table>
+</j:jelly>

--- a/src/main/webapp/help/help-StatusThresholds.html
+++ b/src/main/webapp/help/help-StatusThresholds.html
@@ -1,0 +1,9 @@
+<div>
+	<p>
+		If the total number of stop/warn actions is greater or equal than one of the specified thresholds,
+		a build is considered as unstable or failed, respectively.
+	</p>
+	<p>
+		Leave the field empty if the state of the build should not be influenced by the number of stop/warn actions.
+	</p>
+</div>


### PR DESCRIPTION
This improves the integration of the Anchore report with Jenkins:

1. More control of build result, based on the total warn and/or stop action counts.
It's now possible to define thresholds for warn/stop actions to mark a build as failed/unstable.
Default is at least one stop action fails the build (replacing the default bail on fail) and at least one warn action marks the build as unstable
2. Added a health metric that takes the total warn/stop actions into account, with separately configurable amplification factors (default being 5% for warn and 25% for stop actions)
3. Show a trend graph and a link to the latest Anchore report on a job's page

Tested with Jenkins pipeline and Freestyle Job on current LTS Jenkins ver. 2.150.1