### PR TITLE
Add configuration option to preserve build artifacts in the workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ target/
 # IDE
 .idea
 *.iml
+# VS Code
+.settings/
+.project
+.factorypath
+.classpath
 
 # OS
 .DS_Store

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreBuilder.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreBuilder.java
@@ -118,7 +118,6 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
     return engineverify;
   }
 
-
   @DataBoundSetter
   public void setEngineRetries(String engineRetries) {
     this.engineRetries = engineRetries;
@@ -224,7 +223,8 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
           !Strings.isNullOrEmpty(engineurl) ? engineurl : globalConfig.getEngineurl(),
           !Strings.isNullOrEmpty(engineuser) ? engineuser : globalConfig.getEngineuser(),
           !Strings.isNullOrEmpty(enginepass) ? enginepass : globalConfig.getEnginepass().getPlainText(),
-          isEngineverifyOverrride ? engineverify : globalConfig.getEngineverify());
+          isEngineverifyOverrride ? engineverify : globalConfig.getEngineverify(),
+          globalConfig.getPreserveartifacts());
       worker = new BuildWorker(run, workspace, launcher, listener, config);
 
       /* Log any build time overrides are at play */
@@ -321,6 +321,7 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
     private String engineuser;
     private Secret enginepass;
     private boolean engineverify;
+    private boolean preserveartifacts;
 
     // Upgrade case, you can never really remove these variables once they are introduced
     @Deprecated
@@ -351,6 +352,10 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
       this.engineverify = engineverify;
     }
 
+    public void setPreserveartifacts(boolean preserveartifacts){
+      this.preserveartifacts = preserveartifacts;
+    }
+
     public boolean getDebug() {
       return debug;
     }
@@ -374,6 +379,10 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
 
     public boolean getEngineverify() {
       return engineverify;
+    }
+
+    public boolean getPreserveartifacts(){
+      return preserveartifacts;
     }
 
     public DescriptorImpl() {

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/BuildConfig.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/BuildConfig.java
@@ -25,10 +25,11 @@ public class BuildConfig {
   private String engineuser;
   private String enginepass;
   private boolean engineverify;
+  private boolean preserveartifacts;
 
   public BuildConfig(String name,  String engineRetries, boolean bailOnFail, boolean bailOnPluginFail,
       String policyBundleId, List<Annotation> annotations, boolean autoSubscribeTagUpdates, boolean forceAnalyze, boolean debug,
-      String engineurl, String engineuser, String enginepass, boolean engineverify) {
+      String engineurl, String engineuser, String enginepass, boolean engineverify, boolean preserveartifacts) {
     this.name = name;
     this.engineRetries = engineRetries;
     this.bailOnFail = bailOnFail;
@@ -42,6 +43,7 @@ public class BuildConfig {
     this.engineuser = engineuser;
     this.enginepass = enginepass;
     this.engineverify = engineverify;
+    this.preserveartifacts = preserveartifacts;
   }
 
   public String getName() {
@@ -96,6 +98,10 @@ public class BuildConfig {
     return engineverify;
   }
 
+  public boolean getPreserveartifacts(){
+    return preserveartifacts;
+  }
+
   public void print(ConsoleLog consoleLog) {
     consoleLog.logInfo("[global] debug: " + String.valueOf(debug));
 
@@ -104,6 +110,7 @@ public class BuildConfig {
     consoleLog.logInfo("[build] engineuser: " + engineuser);
     consoleLog.logInfo("[build] enginepass: " + "****");
     consoleLog.logInfo("[build] engineverify: " + String.valueOf(engineverify));
+    consoleLog.logInfo("[build] preserveartifacts: " + String.valueOf(preserveartifacts));
 
     // Build properties
     consoleLog.logInfo("[build] name: " + name);

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
@@ -733,23 +733,24 @@ public class BuildWorker {
   }
 
   public void cleanup() {
-    try {
-      console.logDebug("Cleaning up build artifacts");
-      int rc;
+    if(!this.config.getPreserveartifacts()){
+      try {
+        console.logDebug("Cleaning up build artifacts");
 
-      // Clear Jenkins workspace
-      if (!Strings.isNullOrEmpty(jenkinsOutputDirName)) {
-        try {
-          console.logDebug("Deleting Jenkins workspace " + jenkinsOutputDirName);
-          cleanJenkinsWorkspaceQuietly();
-          // FilePath jenkinsOutputDirFP = new FilePath(build.getWorkspace(), jenkinsOutputDirName);
-          // jenkinsOutputDirFP.deleteRecursive();
-        } catch (IOException | InterruptedException e) {
-          console.logDebug("Unable to delete Jenkins workspace " + jenkinsOutputDirName, e);
+        // Clear Jenkins workspace
+        if (!Strings.isNullOrEmpty(jenkinsOutputDirName)) {
+          try {
+            console.logDebug("Deleting Jenkins workspace " + jenkinsOutputDirName);
+            cleanJenkinsWorkspaceQuietly();
+            // FilePath jenkinsOutputDirFP = new FilePath(build.getWorkspace(), jenkinsOutputDirName);
+            // jenkinsOutputDirFP.deleteRecursive();
+          } catch (IOException | InterruptedException e) {
+            console.logDebug("Unable to delete Jenkins workspace " + jenkinsOutputDirName, e);
+          }
         }
+      } catch (RuntimeException e) { // caught unknown exception, log it
+        console.logDebug("Failed to clean up build artifacts due to an unexpected error", e);
       }
-    } catch (RuntimeException e) { // caught unknown exception, log it
-      console.logDebug("Failed to clean up build artifacts due to an unexpected error", e);
     }
   }
 
@@ -839,7 +840,6 @@ public class BuildWorker {
       FilePath inputImageFP = new FilePath(workspace, config.getName()); // Already checked in checkConfig()
       try (BufferedReader br = new BufferedReader(new InputStreamReader(inputImageFP.read(), StandardCharsets.UTF_8))) {
         String line;
-        int count = 0;
         while ((line = br.readLine()) != null) {
           String imgId = null;
           String jenkinsDFile = null;

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/global.jelly
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/global.jelly
@@ -23,6 +23,10 @@
       <f:checkbox name="debug" checked="${descriptor.debug}" default="${false}"/>
     </f:entry>
 
+    <f:entry title="Preserve Scan Artifacts" field="preserveartifacts">
+      <f:checkbox name="preserveartifacts" checked="${descriptor.preserveartifacts}" default="${false}"/>
+    </f:entry>
+
   </f:section>
 
 </j:jelly>

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/help-preserveartifacts.html
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/help-preserveartifacts.html
@@ -1,0 +1,5 @@
+<div>
+
+  If selected, the plugin will not delete build artifacts from the workspace.
+
+</div>


### PR DESCRIPTION
Add an option to leave the build artifacts in the workspace (cleanup is still default behavior).

With a previous scanner, I was using the json output to summarize and post information about the scan to Slack.  This is just to allow the same functionality with Anchore without having to write an integration with the API.