### PR TITLE
[JENKINS-64248] Fix file path issue for matrix jobs.

### DIFF
--- a/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
@@ -838,11 +838,9 @@ public class BuildWorker {
         throw new AbortException("Unable to generate a unique identifier for this build due to invalid configuration");
       }
 
-      // ArtifactArchiver.perform() cannot parse file paths with commas, which this will have in some cases, for
-      // example if this is a matrix job. So replace any commas with underscores to separate the matrix values.
-      buildId = buildId.replaceAll(",", "_");
-
-      jenkinsOutputDirName = JENKINS_DIR_NAME_PREFIX + buildId;
+      // ArtifactArchiver.perform() cannot parse file paths with commas, which buildId will have in some cases, for
+      // example if this is a matrix job. So replace any commas in it with underscores to separate the matrix values.
+      jenkinsOutputDirName = JENKINS_DIR_NAME_PREFIX + buildId.replaceAll(",", "_");
       FilePath jenkinsReportDir = new FilePath(workspace, jenkinsOutputDirName);
 
       // Create output directories

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
@@ -838,6 +838,10 @@ public class BuildWorker {
         throw new AbortException("Unable to generate a unique identifier for this build due to invalid configuration");
       }
 
+      // ArtifactArchiver.perform() cannot parse file paths with commas, which this will have in some cases, for
+      // example if this is a matrix job. So replace any commas with underscores to separate the matrix values.
+      buildId = buildId.replaceAll(",", "_");
+
       jenkinsOutputDirName = JENKINS_DIR_NAME_PREFIX + buildId;
       FilePath jenkinsReportDir = new FilePath(workspace, jenkinsOutputDirName);
 


### PR DESCRIPTION
[https://issues.jenkins.io/browse/JENKINS-64248](https://issues.jenkins.io/browse/JENKINS-64248)

Removes any potential commas from the plugin workspace dir name, specifically for the case of matrix/multi-configuration jobs with multiple axis. Without this change the plugin creates a workspace directory for artifacts with commas between the names of the matrix variable values. ArtifactArchiver.perform() cannot properly parse this and fails the job. This change fixes that by replacing any commas in the dir name with underscores.