### PR TITLE
Adds missing serialVersionUID to serializable class

### DIFF
--- a/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreProjectAction.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreProjectAction.java
@@ -123,6 +123,8 @@ public class AnchoreProjectAction implements Action {
       rangeAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits());
 
       StackedAreaRenderer ar = new StackedAreaRenderer2() {
+        private static final long serialVersionUID = 8254915273728909997L;
+
         @Override
         public String generateURL(CategoryDataset data, int row, int column) {
           NumberOnlyBuildLabel label = (NumberOnlyBuildLabel) data.getColumnKey(column);


### PR DESCRIPTION
This fixes a warning about missing serialVersionUID to a serializable class in the plugin. Spotbugs in newer jenkins parent pom will block the build due to this.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
