### PR TITLE
Fix gate results actions count per image

### DIFF
--- a/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/BuildWorker.java
@@ -943,13 +943,12 @@ public class BuildWorker {
     if (gatesJson != null) {
       JSONArray summaryRows = new JSONArray();
 
-      int stop = 0, warn = 0, go = 0, stop_wl = 0, warn_wl = 0, go_wl = 0;
-
       for (Object gateResult : gatesJson) {
         JSONArray evaluationFindingContent = JSONObject.fromObject(gateResult).getJSONArray("gate_results");
         String repoTag = JSONObject.fromObject(gateResult).getString("repo_tag");
         String imageDigest = JSONObject.fromObject(gateResult).getString("image_digest");
         String final_action = JSONObject.fromObject(gateResult).getString("final_action");
+        int stop = 0, warn = 0, go = 0, stop_wl = 0, warn_wl = 0, go_wl = 0;
 
         for (Object finding : evaluationFindingContent) {
           if (null != finding) {


### PR DESCRIPTION
This fixes the issue described in https://issues.jenkins.io/browse/JENKINS-72570

### Testing done

I've tested this by running Jenkins in my laptop with connection to Anchore Enterprise Server.

The results are the same as when using API v1 which was working fine before changing to API v2.

Build log excerpts:
```
2024-01-17T01:36:07.400 INFO   AnchoreWorker   Jenkins version: 2.426.2
2024-01-17T01:36:07.401 INFO   AnchoreWorker   Anchore Container Image Scanner Plugin version: 1.1.2-SNAPSHOT (private-a03c6cd2-josesa)
(...)
2024-01-17T01:36:53.160 DEBUG  AnchoreWorker   Summarizing policy evaluation results
2024-01-17T01:36:53.164 INFO   AnchoreWorker   Policy evaluation summary for node:17.5-slim - stop: 46 (+0 allowlisted), warn: 21 (+0 allowlisted), go: 1 (+0 allowlisted), final: stop
2024-01-17T01:36:53.170 INFO   AnchoreWorker   Policy evaluation summary for httpd:2.2.31-alpine - stop: 73 (+0 allowlisted), warn: 63 (+0 allowlisted), go: 1 (+0 allowlisted), final: stop
2024-01-17T01:36:53.171 INFO   AnchoreWorker   Policy evaluation summary for alpine:3.18.0 - stop: 5 (+0 allowlisted), warn: 10 (+0 allowlisted), go: 1 (+0 allowlisted), final: stop
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```