### PR TITLE
feat: dependency updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:  # Should be run in project root	- results go in `target/`
 		-v maven-repo:/root/.m2 \
 		-v "${shell pwd}":/usr/src/mymaven \
 		-w /usr/src/mymaven \
-		maven:3.9.3-eclipse-temurin-8-focal \
+		maven:3.9.6-eclipse-temurin-11-focal \
 		mvn clean install
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.77</version>
+    <version>4.78</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.6.1.1</version>
+	  <version>1311.vcf0a_900b_37c2</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.24</version>
+      <version>337.v1b_04ea_4df7c8</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.19</version>
+    <version>4.77</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-	  <version>1311.vcf0a_900b_37c2</version>
+      <version>1319.v7eb_51b_3a_c97b_</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.414.3</jenkins.version>
     <!-- Java Level to use. Java 8 required when using core >= 1.612 -->
     <java.level>8</java.level>
     <!-- Jenkins Test Harness version you use to test the plugin. -->


### PR DESCRIPTION
- feat: Bump minimum required version of Jenkins to 2.414.3
    This is the currently recommended minimum for plugins. Updating this
    allows us to a newer version of org.jenkins-ci.plugins:plugin which
    since version 4.52 requires Jenkins 2.361 or newer.
- chore: bump maven to latest using JDK 11
    This is a requirement for updating to the latest parent pom for Jenkins
    plugins (https://github.com/jenkinsci/plugin-pom/tree/plugin-4.77)
- feat: bump org.jenkins-ci.plugins:plugin from 4.19 to 4.77
- feat: bump org.jenkins-ci.plugins:structs from 1.24 to 337.v1b_04ea_4df7c8
- feat: bump org.jenkins-ci.plugins:credentials from 2.6.1.1 to 1311.vcf0a_900b_37c2


### Testing done

Tested against a local Jenkins deployment and ran a job that looked for policy evaluation results for three images:
```
2024-01-19T22:33:37.795 DEBUG  AnchoreWorker   Summarizing policy evaluation results
2024-01-19T22:33:37.801 INFO   AnchoreWorker   Policy evaluation summary for docker.io/node:17.5-slim - stop: 47 (+0 allowlisted), warn: 24 (+0 allowlisted), go: 0 (+0 allowlisted), final: stop
2024-01-19T22:33:37.808 INFO   AnchoreWorker   Policy evaluation summary for docker.io/httpd:2.2.31-alpine - stop: 248 (+0 allowlisted), warn: 146 (+0 allowlisted), go: 0 (+0 allowlisted), final: stop
2024-01-19T22:33:37.808 INFO   AnchoreWorker   Policy evaluation summary for docker.io/alpine:3.18.0 - stop: 5 (+0 allowlisted), warn: 11 (+0 allowlisted), go: 0 (+0 allowlisted), final: stop
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
