### PR TITLE
chore: fix makefile pinned jenkins version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,8 @@ build:  # Should be run in project root	- results go in `target/`
 .PHONY: run-jenkins
 run-jenkins:
 	docker run -p 8080:8080 -p 50000:50000 --restart=on-failure -v jenkins_home:/var/jenkins_home jenkins/jenkins:lts-jdk11
+
+
+.PHONY: run-jenkins-oldest  # The minimum version supported by the project
+run-jenkins-oldest:
+	docker run -p 8080:8080 -p 50000:50000 --restart=on-failure -v jenkins_home:/var/jenkins_home jenkins/jenkins:2.414.3-lts-jdk11


### PR DESCRIPTION
Fix the `run-jenkins` Makefile command so it brings up a version of Jenkins in line with the recently bumped minimum supported version