### PR TITLE
feat: bump minimum supported jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.414.3</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <!-- Java Level to use. Java 8 required when using core >= 1.612 -->
     <java.level>8</java.level>
     <!-- Jenkins Test Harness version you use to test the plugin. -->


### PR DESCRIPTION
determined by jenkins credentials plugin:
org.jenkins-ci.plugins:credentials:jar:1337.v60b_d7b_c7b_c9f requires Jenkins 2.426.3 or higher

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
