### PR TITLE
Add Anchore Enterprise account configuration field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>anchore-container-scanner</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
+  <version>3.1.0</version>
   <packaging>hpi</packaging>
   <name>Anchore Container Image Scanner Plugin</name>
   <description>Integrates Jenkins with the Anchore Image Scanner</description>

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreBuilder.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/AnchoreBuilder.java
@@ -70,6 +70,7 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
   // Override global config. Supported for anchore-enterprise mode config only
   private String engineurl = DescriptorImpl.EMPTY_STRING;
   private String engineCredentialsId = DescriptorImpl.EMPTY_STRING;
+  private String engineaccount = DescriptorImpl.EMPTY_STRING;
   private boolean engineverify = false;
   // More flags to indicate boolean override, ugh!
   private boolean isEngineverifyOverrride = false;
@@ -117,6 +118,10 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
 
   public String getEngineCredentialsId() {
     return engineCredentialsId;
+  }
+
+  public String getEngineaccount() {
+    return engineaccount;
   }
 
   public boolean getEngineverify() {
@@ -172,6 +177,11 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
   @DataBoundSetter
   public void setEngineCredentialsId(String engineCredentialsId) {
     this.engineCredentialsId = engineCredentialsId;
+  }
+
+  @DataBoundSetter
+  public void setEngineaccount(String engineaccount) {
+    this.engineaccount = engineaccount;
   }
 
   @DataBoundSetter
@@ -234,6 +244,7 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
           !Strings.isNullOrEmpty(engineurl) ? engineurl : globalConfig.getEngineurl(),
           !Strings.isNullOrEmpty(engineuser) ? engineuser : globalConfig.getEngineuser(),
           !Strings.isNullOrEmpty(enginepass) ? enginepass : globalConfig.getEnginepass().getPlainText(),
+          !Strings.isNullOrEmpty(engineaccount) ? engineaccount : globalConfig.getEngineaccount(),
           isEngineverifyOverrride ? engineverify : globalConfig.getEngineverify());
       worker = new BuildWorker(run, workspace, launcher, listener, config);
 
@@ -243,6 +254,9 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
       }
       if (!Strings.isNullOrEmpty(engineuser) && !Strings.isNullOrEmpty(enginepass)) {
         console.logInfo("Build override set for Anchore Engine credentials");
+      }
+      if (!Strings.isNullOrEmpty(engineaccount)) {
+        console.logInfo("Build override set for Anchore Engine account");
       }
       if (isEngineverifyOverrride) {
         console.logInfo("Build override set for Anchore Engine verify SSL");
@@ -331,6 +345,7 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
     private String engineurl;
     private String engineuser;
     private Secret enginepass;
+    private String engineaccount;
     private boolean engineverify;
 
     // Upgrade case, you can never really remove these variables once they are introduced
@@ -358,6 +373,10 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
       this.enginepass = enginepass;
     }
 
+    public void setEngineaccount(String engineaccount) {
+      this.engineaccount = engineaccount;
+    }
+
     public void setEngineverify(boolean engineverify) {
       this.engineverify = engineverify;
     }
@@ -381,6 +400,10 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
 
     public Secret getEnginepass() {
       return enginepass;
+    }
+
+    public String getEngineaccount() {
+      return engineaccount;
     }
 
     public boolean getEngineverify() {

--- a/src/main/java/com/anchore/jenkins/plugins/anchore/BuildConfig.java
+++ b/src/main/java/com/anchore/jenkins/plugins/anchore/BuildConfig.java
@@ -26,12 +26,13 @@ public class BuildConfig {
   private String engineurl;
   private String engineuser;
   private String enginepass;
+  private String engineaccount;
   private boolean engineverify;
   private API_VERSION engineApiVersion;
 
   public BuildConfig(String name,  String engineRetries, boolean bailOnFail, boolean bailOnPluginFail,
       String policyBundleId, List<Annotation> annotations, boolean autoSubscribeTagUpdates, boolean forceAnalyze, boolean excludeFromBaseImage,
-      boolean debug, String engineurl, String engineuser, String enginepass, boolean engineverify) {
+      boolean debug, String engineurl, String engineuser, String enginepass, String engineaccount, boolean engineverify) {
     this.name = name;
     this.engineRetries = engineRetries;
     this.bailOnFail = bailOnFail;
@@ -45,6 +46,7 @@ public class BuildConfig {
     this.engineurl = engineurl;
     this.engineuser = engineuser;
     this.enginepass = enginepass;
+    this.engineaccount = engineaccount;
     this.engineverify = engineverify;
     this.engineApiVersion = Util.GET_API_VERSION_FROM_URL(engineurl);
   }
@@ -101,6 +103,10 @@ public class BuildConfig {
     return enginepass;
   }
 
+  public String getEngineaccount() {
+    return engineaccount;
+  }
+
   public boolean getEngineverify() {
     return engineverify;
   }
@@ -116,6 +122,7 @@ public class BuildConfig {
     consoleLog.logInfo("[build] engineurl: " + engineurl);
     consoleLog.logInfo("[build] engineuser: " + engineuser);
     consoleLog.logInfo("[build] enginepass: " + "****");
+    consoleLog.logInfo("[build] engineaccount: " + engineaccount);
     consoleLog.logInfo("[build] engineverify: " + String.valueOf(engineverify));
 
     // Build properties

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/config.jelly
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/config.jelly
@@ -55,6 +55,10 @@
         <c:select/>
       </f:entry>
 
+      <f:entry title="Anchore Enterprise account" field="engineaccount" help="/plugin/anchore-container-scanner/help/help-OverrideAEAccount.html">
+        <f:textbox name="engineaccount" default=""/>
+      </f:entry>
+
       <f:entry title="Anchore Enterprise verify SSL" field="engineverify">
         <f:checkbox name="engineverify" checked="${instance.engineverify}" default="${false}"/>
       </f:entry>

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/global.jelly
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/global.jelly
@@ -15,6 +15,10 @@
       <f:password name="enginepass"/>
     </f:entry>
 
+    <f:entry title="Anchore Enterprise Account" field="engineaccount">
+      <f:textbox name="engineaccount" default=""/>
+    </f:entry>
+
     <f:entry title="Verify SSL" field="engineverify">
       <f:checkbox name="engineverify" checked="${descriptor.engineverify}" default="${true}"/>
     </f:entry>

--- a/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/help-engineaccount.html
+++ b/src/main/resources/com/anchore/jenkins/plugins/anchore/AnchoreBuilder/help-engineaccount.html
@@ -1,0 +1,5 @@
+<div>
+
+  Anchore Enterprise account
+
+</div>

--- a/src/main/webapp/help/help-OverrideAEAccount.html
+++ b/src/main/webapp/help/help-OverrideAEAccount.html
@@ -1,0 +1,6 @@
+<div>
+
+  Override plugin's global settings for Anchore Enterprise account. The override is applicable only to builds in this job and does not change
+  the plugin wide global settings.
+
+</div>


### PR DESCRIPTION
Add account field, this is passed via an http header `x-anchore-account`. (see https://docs.anchore.com/current/docs/api/v2/reference/)

Deployments using this feature (some sort of namespacing) won't be able to use the plugin unless the additional header is passed.

### Testing done

Snippet of logs:
```
Started by user [admin](http://ppettina-u-desk.lal.cisco.com:8080/user/admin)
Running as SYSTEM
Building in workspace /var/jenkins_home/workspace/anchore-test-freestyle
[anchore-test-freestyle] $ /bin/sh -xe /tmp/jenkins10064673279436757283.sh
+ echo registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.0
2024-04-08T15:59:53.241 INFO   AnchoreWorker   Jenkins version: 2.440.2
2024-04-08T15:59:53.241 INFO   AnchoreWorker   Anchore Container Image Scanner Plugin version: 3.1.0
2024-04-08T15:59:53.241 INFO   AnchoreWorker   [global] debug: false
2024-04-08T15:59:53.241 INFO   AnchoreWorker   [build] engineurl: xxxxxxxxxxxxx
2024-04-08T15:59:53.241 INFO   AnchoreWorker   [build] engineuser: _api_key
2024-04-08T15:59:53.242 INFO   AnchoreWorker   [build] enginepass: ****
2024-04-08T15:59:53.242 INFO   AnchoreWorker   [build] engineaccount: platform
2024-04-08T15:59:53.242 INFO   AnchoreWorker   [build] engineverify: true
2024-04-08T15:59:53.242 INFO   AnchoreWorker   [build] name: anchore_images
2024-04-08T15:59:53.242 INFO   AnchoreWorker   [build] engineRetries: 300
2024-04-08T15:59:53.242 INFO   AnchoreWorker   [build] policyBundleId: 
2024-04-08T15:59:53.242 INFO   AnchoreWorker   [build] bailOnFail: true
2024-04-08T15:59:53.243 INFO   AnchoreWorker   [build] bailOnPluginFail: true
2024-04-08T15:59:53.243 INFO   AnchorePlugin   Build override set for Anchore Engine URL
2024-04-08T15:59:53.243 INFO   AnchorePlugin   Build override set for Anchore Engine credentials
2024-04-08T15:59:53.243 INFO   AnchorePlugin   Build override set for Anchore Engine account
2024-04-08T15:59:53.243 INFO   AnchorePlugin   Build override set for Anchore Engine verify SSL
2024-04-08T15:59:53.244 INFO   AnchoreWorker   Submitting registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.0 for analysis
2024-04-08T15:59:54.831 INFO   AnchoreWorker   Analysis request accepted, received image digest sha256:d57a19c4b9258e7424f09afb7fea7aaa4942529a03e1f0d9fe47f135899ca43b
2024-04-08T15:59:54.832 INFO   AnchoreWorker   Waiting for analysis of registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.0, polling status periodically
2024-04-08T16:00:43.298 INFO   AnchoreWorker   Completed analysis and processed policy evaluation result
2024-04-08T16:00:43.308 INFO   AnchoreWorker   Policy evaluation summary for registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.0 - stop: 0 (+0 allowlisted), warn: 3 (+0 allowlisted), go: 0 (+0 allowlisted), final: warn
2024-04-08T16:00:43.310 INFO   AnchoreWorker   Anchore Container Image Scanner Plugin step result - PASS
2024-04-08T16:00:44.032 INFO   AnchoreWorker   Querying vulnerability listing for registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.0
Archiving artifacts
2024-04-08T16:00:44.350 INFO   AnchorePlugin   Marking Anchore Container Image Scanner step as successful, final result PASS
2024-04-08T16:00:44.351 INFO   AnchorePlugin   Completed Anchore Container Image Scanner step
Finished: SUCCESS
```
Will provide more evidence if the maintainer requires it :)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
